### PR TITLE
Changed SMB Version from 1 to 2 and 3

### DIFF
--- a/basedir/etc/samba/smb.conf
+++ b/basedir/etc/samba/smb.conf
@@ -37,10 +37,10 @@ passdb backend = smbpasswd:/etc/samba/smbpasswd
 # Change this to the workgroup/NT-domain name your Samba server will part of
    workgroup = WORKGROUP
    #server max protocol = NT1
-server max protocol = NT1
-server min protocol = NT1
-#server min protocol = SMB2_10
-#server max protocol = SMB3_11
+#server max protocol = NT1
+#server min protocol = NT1
+server min protocol = SMB2_10
+server max protocol = SMB3_11
 lm announce = yes
 lm interval = 90
 preferred master = yes


### PR DESCRIPTION
Hey,
after changing the need for the Arduino I installed the Software in an VM.

Works flawless. After trying to connect i got an Error that the Share ist using SMB v1. 
That Version is not safe an disabled by default in newer Win 10 Versions. I changed the smb.conf and it worked without breaking anything I think, still trying out :) 